### PR TITLE
HOTFIX: [COSY-68] short sha tag

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get short SHA
-        id:  short-sha
-        run: echo "sha=$(echo ${{ github. sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+        id: short-sha
+        run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
fix: Use short SHA for docker iamge tags in deployment workflow trigger