### PR TITLE
[HOTFIX] Add fetch method POST in startServiceSse

### DIFF
--- a/src/api/sse.ts
+++ b/src/api/sse.ts
@@ -11,6 +11,7 @@ type StartEventDto =
 
 export async function startServiceSse(serviceName: string): Promise<GameServerInstanceDto> {
   const response = await fetch(`/api/game-server/${serviceName}/start`, {
+    method: "POST",
     headers: {
       Authorization: `Bearer ${getAuthToken()}`,
       Accept: "text/event-stream",
@@ -68,3 +69,4 @@ export async function startServiceSse(serviceName: string): Promise<GameServerIn
     read();
   });
 }
+


### PR DESCRIPTION
Problem: Gameserver laesst sich nicht starten, da Endpunkt 401 Fehler zurueck gibt.

Das fehlen der http method bei der definition fuehrt dazu, dass  per default GET gewaehlt wird. Das backend erwartet aber POST als Method fuer den request zu  `/api/game-server/<serviceName>/start`.

Fix: "POST" als method explizit definieren