### PR TITLE
[cosy-141] inject limits from template

### DIFF
--- a/src/components/display/GameServer/CreateGameServer/utils/templateSubstitution.ts
+++ b/src/components/display/GameServer/CreateGameServer/utils/templateSubstitution.ts
@@ -1,10 +1,10 @@
 import {
   type EnvironmentVariableConfiguration,
-  type GameServerCreationDto,
   type PortMapping,
   PortMappingProtocol,
   type TemplateEntity,
 } from "@/api/generated/model";
+import type { GameServerCreationFormState } from "../CreateGameServerModal";
 
 /**
  * Substitutes template variables in a string
@@ -31,9 +31,9 @@ export function substituteVariables(
 export function applyTemplate(
   template: TemplateEntity,
   variables: Record<string, string | number | boolean>,
-  currentState: Partial<GameServerCreationDto>,
-): Partial<GameServerCreationDto> {
-  const newState: Partial<GameServerCreationDto> = {...currentState};
+  currentState: GameServerCreationFormState,
+): GameServerCreationFormState {
+  const newState: GameServerCreationFormState = {...currentState};
 
   // Substitute docker image name
   if (template.docker_image_name) {


### PR DESCRIPTION
This pull request updates the `applyTemplate` utility function to better align with the form state used in creating game servers and adds support for applying hardware resource limits from templates. The main changes focus on type safety and feature enhancement for handling hardware limits in the game server creation process.

**Type and Interface Updates:**
* Changed the type of `currentState` and the return type in `applyTemplate` from `Partial<GameServerCreationDto>` to `GameServerCreationFormState` for improved type safety and consistency with the form's state management. [[1]](diffhunk://#diff-3b5879416477518f687b79b7746904bcb814bdf424843fb511f579f4df0372a9L3-R7) [[2]](diffhunk://#diff-3b5879416477518f687b79b7746904bcb814bdf424843fb511f579f4df0372a9L34-R36)

**Feature Enhancements:**
* Added logic to apply hardware resource limits (`cpu` and `memory`) from the template to the form state, converting values as needed for the form.