### PR TITLE
fix: fix weird gap in file browser row buttons

### DIFF
--- a/src/components/display/GameServer/FileBrowser/FileBrowserRow/FileBrowserRow.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserRow/FileBrowserRow.tsx
@@ -102,10 +102,10 @@ export const FileBrowserRow = ({
         </div>
       </div>
 
-      {canWrite && (
-        <>
-          {/* Inline buttons – visible when container >= 500px */}
-          <div className="hidden @[500px]:flex items-center gap-1 shrink-0">
+      <div className="hidden @[500px]:flex items-center gap-1 shrink-0">
+        {canWrite && (
+          <>
+            {/* Inline buttons – visible when container >= 500px */}
             {onRename ? (
               <TooltipWrapper tooltip={t("renameAction")}>
                 <button
@@ -151,49 +151,49 @@ export const FileBrowserRow = ({
                 </button>
               </TooltipWrapper>
             ) : null}
-          </div>
-        </>
-      )}
+          </>
+        )}
 
-      {onDownload && !dir && (
-        <TooltipWrapper tooltip={t("downloadAction")}>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDownload(obj);
-            }}
-            className={actionButtonClass}
-            disabled={loading || downloadingFiles.includes(filePath)}
-            data-loading={loading}
-            aria-label={`${t("downloadAction")} ${obj.name}`}
-          >
-            <Download className="h-4 w-4 mr-1" />
-            <span className="hidden sm:inline">
-              {!isBeingDownloaded ? t("downloadAction") : t("loading")}
-            </span>
-          </button>
-        </TooltipWrapper>
-      )}
+        {onDownload && !dir && (
+          <TooltipWrapper tooltip={t("downloadAction")}>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDownload(obj);
+              }}
+              className={actionButtonClass}
+              disabled={loading || downloadingFiles.includes(filePath)}
+              data-loading={loading}
+              aria-label={`${t("downloadAction")} ${obj.name}`}
+            >
+              <Download className="h-4 w-4 mr-1" />
+              <span className="hidden sm:inline">
+                {!isBeingDownloaded ? t("downloadAction") : t("loading")}
+              </span>
+            </button>
+          </TooltipWrapper>
+        )}
 
-      {onDownload && dir && (
-        <TooltipWrapper tooltip={t("exportAction")}>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDownload(obj);
-            }}
-            className={actionButtonClass}
-            disabled={loading || downloadingFiles.includes(filePath)}
-            data-loading={loading}
-            aria-label={`${t("exportAction")} ${obj.name}`}
-          >
-            <FolderDown className="h-4 w-4 mr-1" />
-            {!isBeingDownloaded ? t("exportAction") : t("loading")}
-          </button>
-        </TooltipWrapper>
-      )}
+        {onDownload && dir && (
+          <TooltipWrapper tooltip={t("exportAction")}>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDownload(obj);
+              }}
+              className={actionButtonClass}
+              disabled={loading || downloadingFiles.includes(filePath)}
+              data-loading={loading}
+              aria-label={`${t("exportAction")} ${obj.name}`}
+            >
+              <FolderDown className="h-4 w-4 mr-1" />
+              {!isBeingDownloaded ? t("exportAction") : t("loading")}
+            </button>
+          </TooltipWrapper>
+        )}
+      </div>
 
       {canWrite && (
         <div className="@[500px]:hidden shrink-0">


### PR DESCRIPTION
This pull request makes a small adjustment to the layout of inline action buttons in the `FileBrowserRow` component. The main change is moving the container for these buttons outside the conditional rendering logic, ensuring correct visibility and alignment for screens wider than 500px.

* Layout adjustment: Moved the `div` with class `hidden @[500px]:flex items-center gap-1 shrink-0` outside the conditional rendering of `canWrite` and `onRename` to fix button visibility and alignment for inline actions on wider screens. [[1]](diffhunk://#diff-7758538aad3e8732167c28010e5915853a71337aca2a37c33f195c2f2810a84bR105-L108) [[2]](diffhunk://#diff-7758538aad3e8732167c28010e5915853a71337aca2a37c33f195c2f2810a84bL154) [[3]](diffhunk://#diff-7758538aad3e8732167c28010e5915853a71337aca2a37c33f195c2f2810a84bR196)