### PR TITLE
[FIX] fix: adjust sizing and position of metrics loading icon

### DIFF
--- a/src/components/display/GameServer/GameServerSettings/sections/PrivateDashboardSetting/PrivateDashboardSettingsSection.tsx
+++ b/src/components/display/GameServer/GameServerSettings/sections/PrivateDashboardSetting/PrivateDashboardSettingsSection.tsx
@@ -170,14 +170,15 @@ export default function PrivateDashboardSettingsSection(props: { gameServer: Gam
                   className="flex-1"
                   metricType={dashboard.metric_type || MetricsType.CPU_PERCENT}
                   setMetricType={(type) => handleMetricTypeChange(type, dashboard._uiUuid)}
-                />
-              )}
+                  gameServerUuid={props.gameServer.uuid}
+                  />
+                )}
               {dashboard.private_dashboard_types ===
                 PrivateDashboardLayoutPrivateDashboardTypes.FREETEXT && (
-                <Button variant={"secondary"} onClick={() => handleFreeTextEdit(dashboard)}>
-                  <SquarePen className="size-6" />
-                </Button>
-              )}
+                  <Button variant={"secondary"} onClick={() => handleFreeTextEdit(dashboard)}>
+                    <SquarePen className="size-6" />
+                  </Button>
+                )}
             </div>
           </>
         )}

--- a/src/components/display/MetricDisplay/MetricDisplay.tsx
+++ b/src/components/display/MetricDisplay/MetricDisplay.tsx
@@ -74,15 +74,15 @@ const MetricDisplay = (
           {liveEnabled ? t("metrics.liveMetricsOn") : t("metrics.liveMetricsOff")}
         </Button>
       </div>
-      {loading && (
-        <div className="absolute z-10 flex justify-center items-center w-[80%] h-[80%] backdrop-blur-sm">
-          <div className="flex flex-col gap-2">
-            <img src={spinner} alt="spinner" />
-            <div className="flex justify-center text-xl">{t("signIn.loading")}</div>
+      <div className="grid grid-cols-6 gap-2 w-full h-auto mb-auto relative">
+        {loading && (
+          <div className="absolute z-10 flex justify-center items-center w-full h-full backdrop-blur-sm">
+            <div className="flex flex-col gap-2">
+              <img src={spinner} alt="spinner" />
+              <div className="flex justify-center text-xl">{t("signIn.loading")}</div>
+            </div>
           </div>
-        </div>
-      )}
-      <div className="grid grid-cols-6 gap-2 w-full h-auto mb-auto">
+        )}
         {gameServer.metric_layout?.map((metric) => (
           <MetricGraph
             key={metric.metric_type}


### PR DESCRIPTION
This pull request improves the layout and loading experience in the `MetricDisplay` component. The most important change is the adjustment of the loading overlay to cover the entire metrics grid, ensuring a consistent and visually clear loading state.

Layout and loading improvements:

* Changed the loading overlay in `MetricDisplay.tsx` to cover the full width and height of the metrics grid, enhancing the user experience during loading.
* Moved the metrics grid container to wrap both the loading overlay and the metrics display, ensuring proper layering and layout.