### PR TITLE
hotfix: update console arrow color for better visibility

### DIFF
--- a/src/components/display/LogDisplay/LogDisplay.tsx
+++ b/src/components/display/LogDisplay/LogDisplay.tsx
@@ -196,7 +196,9 @@ const LogDisplay = (
             disabled={!isServerRunning}
             className="bg-gray-900 border-gray-700 text-gray-100 font-mono text-[15px] placeholder:text-gray-500 grow w-auto h-10"
             wrapperClassName={"w-auto grow"}
-            startDecorator={<Icon src={arrowRightIcon} className="size-4" variant="foreground" />}
+            startDecorator={
+              <Icon src={arrowRightIcon} className="size-4 opacity-50" variant="primary" />
+            }
           />
           <Button
             onClick={handleSendCommand}


### PR DESCRIPTION
This pull request makes a minor visual adjustment to the `LogDisplay` component's input field. The change updates the appearance of the start decorator icon to improve its visual hierarchy and clarity.

- UI improvement:
  * [`LogDisplay.tsx`](diffhunk://#diff-223b2b5e6d6e418f4bc1961d06ac02574466306f563e10b19a95356573e9bcdaL199-R201): The arrow icon used as the start decorator in the input field now has reduced opacity and uses the `primary` variant instead of `foreground`, making it appear less prominent and more visually consistent with the intended design.