### PR TITLE
fix: server creation flow bugs (step2 skip, error modal stacking, uns…

### DIFF
--- a/src/components/display/GameServer/CreateGameServer/CreateGameServerModal.tsx
+++ b/src/components/display/GameServer/CreateGameServer/CreateGameServerModal.tsx
@@ -89,6 +89,15 @@ const CreateGameServerModal = ({ setOpen, isOpen }: Props) => {
               <DialogContent
                 className="static translate-x-0 translate-y-0 flex w-[60vw] h-[80vh]"
                 asChild
+                onInteractOutside={(e) => {
+                  // The confirm/reapply/unsaved AlertDialogs portal to the body, so
+                  // interacting with them registers as an "outside" interaction here.
+                  // Ignore those so closing a nested dialog doesn't trigger the
+                  // unsaved-changes prompt (or loop it).
+                  if (showConfirmDialog || showReapplyDialog || showUnsavedChangesDialog) {
+                    e.preventDefault();
+                  }
+                }}
               >
                 <DialogHeader>
                   <DialogTitle className={"mr-5"}>

--- a/src/components/display/GameServer/CreateGameServer/useGameServerCreation.ts
+++ b/src/components/display/GameServer/CreateGameServer/useGameServerCreation.ts
@@ -62,7 +62,6 @@ const useGameServerCreation = ({
 
   const [isPageValid, setPageValid] = useState<{ [key: number]: boolean }>({});
   const [currentPage, setCurrentPage] = useState(0);
-  const [skippedStep2, setSkippedStep2] = useState(false);
   const [pendingPageChange, setPendingPageChange] = useState<number | null>(null);
   const [showReapplyDialog, setShowReapplyDialog] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
@@ -101,8 +100,7 @@ const useGameServerCreation = ({
 
       const hasVariables = (template.variables?.length ?? 0) > 0;
       selectTemplate(template, defaults, !hasVariables);
-      setSkippedStep2(!hasVariables);
-      setCurrentPage(hasVariables ? 1 : 2);
+      setCurrentPage(1);
     },
     [selectTemplate],
   );
@@ -114,7 +112,6 @@ const useGameServerCreation = ({
     }
 
     if (currentPage === 0) {
-      setSkippedStep2(false);
       setCurrentPage(1);
       return;
     }
@@ -150,12 +147,8 @@ const useGameServerCreation = ({
     if (currentPage === 1) {
       clearTemplate();
     }
-    if (currentPage === 2 && skippedStep2) {
-      setCurrentPage(0);
-    } else {
-      setCurrentPage((p) => p - 1);
-    }
-  }, [currentPage, skippedStep2, clearTemplate]);
+    setCurrentPage((p) => p - 1);
+  }, [currentPage, clearTemplate]);
 
   const handleConfirmReapply = useCallback(() => {
     applyTemplateToState();
@@ -227,7 +220,6 @@ const useGameServerCreation = ({
       resetCreationState();
       setPageValid({});
       setCurrentPage(0);
-      setSkippedStep2(false);
       setOpen(false);
       setSuccessInfo({ server: createdGameServer });
       setShowSuccessDialog(true);
@@ -256,7 +248,6 @@ const useGameServerCreation = ({
     resetCreationState();
     setPageValid({});
     setCurrentPage(0);
-    setSkippedStep2(false);
     setOpen(false);
   }, [setOpen, resetCreationState]);
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -47,6 +47,7 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   asChild,
@@ -54,6 +55,7 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
   asChild?: boolean;
+  overlayClassName?: string;
 }) {
   const mainContent =
     <DialogPrimitive.Content
@@ -82,7 +84,7 @@ function DialogContent({
   return (
     asChild ? mainContent :
      <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
        {mainContent}
     </DialogPortal>
   );

--- a/src/components/ui/notification-modal.tsx
+++ b/src/components/ui/notification-modal.tsx
@@ -35,7 +35,11 @@ export function NotificationModal({ item }: NotificationModalProps) {
         if (!open) handleDismiss();
       }}
     >
-      <DialogContent showCloseButton={false} className={"max-w-[500px]"}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-[500px] z-[120]"
+        overlayClassName="z-[110]"
+      >
         {item && (
           <>
             <DialogHeader>


### PR DESCRIPTION
## Bugs fixed

1. **Generic Server template skipped the name step** — selecting the "Generic Server" template (a template with no variables) jumped straight to Step 3, so you could never enter the game server name. Step 2 is now always shown.

2. **Error modal hidden behind the confirm dialog** — when server creation failed, the error notification rendered *behind* the "Are you sure you want to create the server?" dialog, so you couldn't read it. The notification/error modal now always renders on top.

3. **"No, go back" opened the Unsaved-changes modal** — clicking "Create Server" and then "No, go back" spuriously popped up the Unsaved-changes modal, which shouldn't happen.

4. **Unsaved-changes modal couldn't be dismissed** — clicking "Continue editing" on the Unsaved-changes modal just reopened it, trapping the user (only "Verwerfen"/Discard could escape it). It now closes correctly.

Bugs 3 and 4 shared one root cause: the nested confirm/unsaved AlertDialogs portal to the document body, so interacting with them registered as an "outside" interaction on the wizard dialog and triggered its close/unsaved-changes flow.
