### PR TITLE
fix: exempt file transfers from the 4s default request timeout

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -12,6 +12,9 @@ export const AXIOS_INSTANCE = axios.create({
   baseURL: "/api",
 });
 
+// Large file transfers must not be killed by the default 4 s request timeout.
+export const FILE_TRANSFER_OPTIONS: AxiosRequestConfig = { timeout: 0 };
+
 let authToken: string | null = null;
 
 export const setAuthToken = (token: string | null) => {

--- a/src/components/display/GameServer/FileBrowser/FileBrowserDialog/FileBrowserDialog.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserDialog/FileBrowserDialog.tsx
@@ -3,6 +3,7 @@ import Icon from "@components/ui/Icon.tsx";
 import { Input } from "@components/ui/input";
 import TooltipWrapper from "@components/ui/TooltipWrapper";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FILE_TRANSFER_OPTIONS } from "@/api/axiosInstance";
 import {
   readFileFromVolume,
   setPermissions,
@@ -132,7 +133,7 @@ export const FileBrowserDialog = (props: FileBrowserDialogProps) => {
     const path = joinRemotePath(currentPath, file.name);
     const apiPath = path === "/" ? "" : path;
 
-    await uploadFileToVolume(props.serverUuid, file, { path: apiPath });
+    await uploadFileToVolume(props.serverUuid, file, { path: apiPath }, FILE_TRANSFER_OPTIONS);
     await ensurePathFetched(currentPath, fetchDepth, true);
   };
 
@@ -162,10 +163,15 @@ export const FileBrowserDialog = (props: FileBrowserDialogProps) => {
     const targetPath = subdirectory ? `${base}/${subdirectory}` : base;
     const sorted = [...pendingArchives].sort((a, b) => a.name.localeCompare(b.name));
     for (let i = 0; i < sorted.length; i++) {
-      await uploadArchiveToVolume(props.serverUuid, sorted[i] as unknown as Blob, {
-        path: targetPath,
-        clear: i === 0 && clear,
-      });
+      await uploadArchiveToVolume(
+        props.serverUuid,
+        sorted[i] as unknown as Blob,
+        {
+          path: targetPath,
+          clear: i === 0 && clear,
+        },
+        FILE_TRANSFER_OPTIONS,
+      );
     }
     await ensurePathFetched(currentPath, fetchDepth, true);
   };
@@ -254,7 +260,7 @@ export const FileBrowserDialog = (props: FileBrowserDialogProps) => {
       const apiPath = path === "/" ? "" : path;
       setEditingFile({ obj, content: null, fetching: true });
       try {
-        const blob = await readFileFromVolume(props.serverUuid, { path: apiPath }) as unknown as Blob;
+        const blob = await readFileFromVolume(props.serverUuid, { path: apiPath }, FILE_TRANSFER_OPTIONS) as unknown as Blob;
         const text = await blob.text();
         setEditingFile({ obj, content: text, fetching: false });
       } catch {
@@ -273,6 +279,7 @@ export const FileBrowserDialog = (props: FileBrowserDialogProps) => {
       props.serverUuid,
       new Blob([content], { type: "text/plain" }),
       { path: apiPath },
+      FILE_TRANSFER_OPTIONS,
     );
     await ensurePathFetched(currentPath, fetchDepth, true);
   };

--- a/src/lib/fileSystemUtils.ts
+++ b/src/lib/fileSystemUtils.ts
@@ -1,3 +1,4 @@
+import { FILE_TRANSFER_OPTIONS } from "@/api/axiosInstance";
 import { readFileFromVolume } from "@/api/generated/backend-api";
 import type { FileSystemObjectDto } from "@/api/generated/model";
 
@@ -172,7 +173,7 @@ export async function downloadSingleFile(opts: {
   const fullPath = joinRemotePath(parentPath, name);
   const apiPath = fullPath === "/" ? "" : fullPath;
 
-  const blob = (await readFileFromVolume(serverUuid, { path: apiPath })) as Blob;
+  const blob = (await readFileFromVolume(serverUuid, { path: apiPath }, FILE_TRANSFER_OPTIONS)) as Blob;
 
   const a = document.createElement("a");
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Problem
Uploading a zip archive through the file browser fails for anything that takes longer than 4 seconds to transfer — the request dies with HTTP status 0 and no server response (observed with a 68 MB archive aborting at exactly 4002 ms).

## Root cause
The Orval mutator in `src/api/axiosInstance.ts` applies a default `timeout: 4000` to **every** generated API call. Axios aborts the upload client-side mid-stream; the server never sees an error (backend logs are clean, no ingress or body-size limit involved).

## Fix
Add an exported `FILE_TRANSFER_OPTIONS = { timeout: 0 }` (axios: 0 = no timeout) and pass it at every call site that transfers file content:

- `uploadArchiveToVolume` — archive upload (the reported bug)
- `uploadFileToVolume` — single-file upload and editor save
- `readFileFromVolume` — editor read and single-file download

The 4 s default stays in place for all other API calls.

## Verification
- `bun run typecheck` ✅
- `bun run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)