### PR TITLE
chore: enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable weekly, grouped dependency updates.

Part of Magenta-Mause/Cosy#54 (enable Dependabot org-wide)

## Ecosystems configured
- `npm` (`/`)
- `docker` (`/`)
- `github-actions` (`/`)

Updates run weekly, are grouped per ecosystem (`patterns: ["*"]`) to reduce PR noise, and are capped at 5 open PRs per ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
