### PR TITLE
feat: add data-testid attributes for e2e system tests

### DIFF
--- a/src/components/display/Configurations/OptionsBannerDropdown/LogOutButton/LogOutAlertDialog.tsx
+++ b/src/components/display/Configurations/OptionsBannerDropdown/LogOutButton/LogOutAlertDialog.tsx
@@ -56,7 +56,13 @@ export function LogOutAlertDialog({ onConfirm, open, onOpenChange }: LogOutAlert
               {t("cancel")}
             </Button>
           </DialogClose>
-          <Button type="button" variant={"destructive"} onClick={handleConfirm} disabled={loading}>
+          <Button
+            type="button"
+            variant={"destructive"}
+            data-testid="logout-confirm-btn"
+            onClick={handleConfirm}
+            disabled={loading}
+          >
             {t("confirm")}
           </Button>
         </DialogFooter>

--- a/src/components/display/Configurations/OptionsBannerDropdown/LogOutButton/LogOutButton.tsx
+++ b/src/components/display/Configurations/OptionsBannerDropdown/LogOutButton/LogOutButton.tsx
@@ -22,6 +22,7 @@ const LogOutButton = forwardRef<HTMLButtonElement, LogOutButtonProps>(
           {...props}
           ref={ref}
           className={cn("h-auto aspect-square", props.className)}
+          data-testid="logout-btn"
           aria-label={t("optionsBanner.logout")}
           onClick={(event) => {
             onClick?.(event);

--- a/src/components/display/Configurations/OptionsBannerDropdown/OptionsBannerDropdown.tsx
+++ b/src/components/display/Configurations/OptionsBannerDropdown/OptionsBannerDropdown.tsx
@@ -76,6 +76,7 @@ const OptionsBannerDropdown = () => {
     // biome-ignore lint/a11y/noStaticElementInteractions: Banner is an interactive container for nested controls
     <div
       id="banner"
+      data-testid="options-banner"
       ref={bannerRef}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}

--- a/src/components/display/GameServer/ConstructionPlace/ConstructionPlaceHouse.tsx
+++ b/src/components/display/GameServer/ConstructionPlace/ConstructionPlaceHouse.tsx
@@ -42,6 +42,7 @@ const ConstructionPlaceHouse = (props: { className?: string; style?: CSSProperti
               props.className,
             )}
             aria-label={t("aria.createNewGameServer")}
+            data-testid="create-server-plot"
             to={"/"}
             style={{
               ...props.style,

--- a/src/components/display/GameServer/CreateGameServer/ConfirmCreateDialog.tsx
+++ b/src/components/display/GameServer/CreateGameServer/ConfirmCreateDialog.tsx
@@ -39,7 +39,12 @@ const ConfirmCreateDialog = ({
           <Button variant="secondary" onClick={onCancel} disabled={isCreating}>
             {t("components.CreateGameServer.confirmCreateDialog.cancel")}
           </Button>
-          <Button variant="primary" onClick={onConfirm} disabled={isCreating}>
+          <Button
+            variant="primary"
+            data-testid="create-confirm-btn"
+            onClick={onConfirm}
+            disabled={isCreating}
+          >
             {isCreating
               ? t("components.CreateGameServer.confirmCreateDialog.creating")
               : t("components.CreateGameServer.confirmCreateDialog.confirm")}

--- a/src/components/display/GameServer/CreateGameServer/GameServerCreationButton.tsx
+++ b/src/components/display/GameServer/CreateGameServer/GameServerCreationButton.tsx
@@ -36,7 +36,13 @@ const GameServerCreationButton = () => {
   return (
     <TooltipWrapper tooltip={disabledTooltip} asChild={false} triggerProps={{ asChild: true }}>
       <span className="inline-flex">
-        <Button type="button" variant="primary" onClick={triggerNextPage} disabled={isDisabled}>
+        <Button
+          type="button"
+          variant="primary"
+          data-testid="create-server-next-btn"
+          onClick={triggerNextPage}
+          disabled={isDisabled}
+        >
           {t(buttonLabel)}
         </Button>
       </span>

--- a/src/components/display/GameServer/CreateGameServer/GenericGameServerCreationInputField.tsx
+++ b/src/components/display/GameServer/CreateGameServer/GenericGameServerCreationInputField.tsx
@@ -116,6 +116,7 @@ const GenericGameServerCreationInputField = (props: {
         step={props.step}
         onChange={(e) => changeCallback(e.target.value)}
         id={props.attribute}
+        data-testid={`create-field-${props.attribute}`}
         value={creationState.gameServerState[props.attribute] as string | number | undefined}
         onKeyDown={(e) => {
           if (e.key === "Enter") {

--- a/src/components/display/GameServer/CreateGameServer/MemoryLimitInputFieldCreation.tsx
+++ b/src/components/display/GameServer/CreateGameServer/MemoryLimitInputFieldCreation.tsx
@@ -121,6 +121,7 @@ const MemoryLimitInputFieldCreation = ({
     <div>
       <MemoryLimitInput
         id={attribute}
+        data-testid={`create-field-${attribute}`}
         header={label}
         isRequired={!optional}
         error={isError ? errorMessage : undefined}

--- a/src/components/display/GameServer/CreateGameServer/SuccessDialog.tsx
+++ b/src/components/display/GameServer/CreateGameServer/SuccessDialog.tsx
@@ -53,7 +53,11 @@ const SuccessDialog = ({ open, onClose, successInfo }: SuccessDialogProps) => {
           <Button variant="secondary" onClick={onClose}>
             {t("components.CreateGameServer.successDialog.doneButton")}
           </Button>
-          <Button variant={"primary"} onClick={openDashboard}>
+          <Button
+            variant={"primary"}
+            data-testid="create-success-open-dashboard-btn"
+            onClick={openDashboard}
+          >
             {t("components.CreateGameServer.successDialog.openDashboard")}
           </Button>
         </DialogFooter>

--- a/src/components/display/GameServer/DeleteGameServerAlertDialog/DeleteGameServerAlertDialog.tsx
+++ b/src/components/display/GameServer/DeleteGameServerAlertDialog/DeleteGameServerAlertDialog.tsx
@@ -88,6 +88,7 @@ export function DeleteGameServerAlertDialog({
             </div>
             <Input
               id="serverName"
+              data-testid="delete-confirm-input"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -105,6 +106,7 @@ export function DeleteGameServerAlertDialog({
           <Button
             type="button"
             variant={"destructive"}
+            data-testid="delete-confirm-btn"
             onClick={handleConfirm}
             className={"h-12.5"}
             disabled={isConfirmButtonDisabled}

--- a/src/components/display/GameServer/EditGameServer/UncosyZone.tsx
+++ b/src/components/display/GameServer/EditGameServer/UncosyZone.tsx
@@ -44,6 +44,7 @@ const UncosyZone = (props: { gameServer: GameServerDto }) => {
               </div>
               <Button
                 variant="destructive"
+                data-testid="server-delete-btn"
                 onClick={() => {
                   setIsDeleteDialogOpen(true);
                 }}

--- a/src/components/display/GameServer/FileBrowser/EditFileModal/EditFileModal.tsx
+++ b/src/components/display/GameServer/FileBrowser/EditFileModal/EditFileModal.tsx
@@ -80,6 +80,7 @@ export const EditFileModal = ({
             </div>
           ) : (
             <textarea
+              data-testid="editfile-textarea"
               className={cn(
                 "flex-1 w-full resize-none rounded-md border border-border bg-muted/30",
                 "px-3 py-2 font-mono text-sm leading-relaxed",
@@ -106,6 +107,7 @@ export const EditFileModal = ({
             onClick={handleSave}
             disabled={busy || fetching}
             data-loading={saving}
+            data-testid="editfile-save-btn"
             className="flex-1"
           >
             {saving ? t("saving") : t("save")}

--- a/src/components/display/GameServer/FileBrowser/FileBrowserHeader/FileBrowserHeader.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserHeader/FileBrowserHeader.tsx
@@ -65,6 +65,7 @@ export const FileBrowserHeader = ({
           <TooltipWrapper tooltip={t("newFolder")}>
             <button
               type="button"
+              data-testid="files-new-folder-btn"
               onClick={onNewFolder}
               className={cn(
                 "inline-flex items-center gap-1 rounded-md px-2 py-1",

--- a/src/components/display/GameServer/FileBrowser/FileBrowserRow/FileBrowserRow.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserRow/FileBrowserRow.tsx
@@ -62,6 +62,7 @@ export const FileBrowserRow = ({
     // biome-ignore lint/a11y/useSemanticElements: <button> cannot be used here — DropdownMenuTrigger is also a <button> and nested buttons are invalid HTML
     <div
       role="button"
+      data-testid="file-row"
       tabIndex={onEntryClick ? 0 : -1}
       aria-disabled={!onEntryClick || undefined}
       onClick={onEntryClick ? () => onEntryClick(obj) : undefined}
@@ -129,6 +130,7 @@ export const FileBrowserRow = ({
           <DropdownMenuTrigger asChild>
             <button
               type="button"
+              data-testid="file-row-menu-btn"
               onClick={(e) => e.stopPropagation()}
               className={cn(
                 "inline-flex items-center justify-center rounded-md p-1.5 shrink-0",

--- a/src/components/display/GameServer/FileBrowser/dialogs/DeleteDialog.tsx
+++ b/src/components/display/GameServer/FileBrowser/dialogs/DeleteDialog.tsx
@@ -46,7 +46,12 @@ export const DeleteDialog = ({ open, onOpenChange, obj, busy, error, t, onSubmit
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={busy}>
             {t("cancel")}
           </Button>
-          <Button variant="destructive" onClick={onSubmit} disabled={busy || !obj}>
+          <Button
+            variant="destructive"
+            onClick={onSubmit}
+            disabled={busy || !obj}
+            data-testid="delete-submit-btn"
+          >
             {busy ? t("deleteInProgress") : t("deleteAction")}
           </Button>
         </DialogFooter>

--- a/src/components/display/GameServer/FileBrowser/dialogs/MkdirDialog.tsx
+++ b/src/components/display/GameServer/FileBrowser/dialogs/MkdirDialog.tsx
@@ -61,6 +61,7 @@ export const MkdirDialog = ({
 
             <Input
               autoFocus
+              data-testid="mkdir-name-input"
               value={value}
               onChange={(e) => {
                 if (!touched) setTouched(true);
@@ -80,7 +81,7 @@ export const MkdirDialog = ({
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={onSubmit} disabled={busy}>
+          <Button onClick={onSubmit} disabled={busy} data-testid="mkdir-submit-btn">
             {busy ? t("creatingInProgress") : t("createAction")}
           </Button>
         </DialogFooter>

--- a/src/components/display/GameServer/FileBrowser/dialogs/RenameDialog.tsx
+++ b/src/components/display/GameServer/FileBrowser/dialogs/RenameDialog.tsx
@@ -61,6 +61,7 @@ export const RenameDialog = ({
             <span className="text-sm text-muted-foreground">{t("newName")}</span>
             <Input
               autoFocus
+              data-testid="rename-name-input"
               value={value}
               onChange={(e) => onChange(e.target.value)}
               placeholder={t("newName")}
@@ -76,7 +77,7 @@ export const RenameDialog = ({
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={busy}>
             {t("cancel")}
           </Button>
-          <Button onClick={onSubmit} disabled={busy || !obj}>
+          <Button onClick={onSubmit} disabled={busy || !obj} data-testid="rename-submit-btn">
             {busy ? t("renameInProgress") : t("renameAction")}
           </Button>
         </DialogFooter>

--- a/src/components/display/GameServer/GameServerDetailPageLayout/GameServerDetailPageLayout.tsx
+++ b/src/components/display/GameServer/GameServerDetailPageLayout/GameServerDetailPageLayout.tsx
@@ -368,6 +368,7 @@ const SideBar = (props: { gameServer: GameServerDto; buttonVariant?: "primary" |
               <FancyNavigationButton
                 isActive={activePathPattern ? activePathPattern.test(location.pathname) : isActive}
                 label={t(`serverPage.navbar.${label}`)}
+                data-testid={`server-tab-${label}`}
                 disabled={!isLinkReachable}
                 variant={props.buttonVariant}
               >

--- a/src/components/display/GameServer/GameServerHouse/GameServerHouse.tsx
+++ b/src/components/display/GameServer/GameServerHouse/GameServerHouse.tsx
@@ -122,6 +122,7 @@ const GameServerHouse = (props: {
           props.className,
         )}
         to={`/server/${props.gameServer.uuid}`}
+        data-testid="server-house"
         aria-label={t("aria.gameServerConfiguration", {
           serverName: props.gameServer.server_name,
         })}

--- a/src/components/display/GameServer/GameServerStartStopButton/GameServerStartStopButton.tsx
+++ b/src/components/display/GameServer/GameServerStartStopButton/GameServerStartStopButton.tsx
@@ -98,6 +98,7 @@ const GameServerStartStopButton = (props: {
     >
       <Button
         {...buttonProps}
+        data-testid="server-start-stop-btn"
         className="transition-all duration-300"
         variant={props.buttonVariant ?? "primary"}
       />

--- a/src/components/display/GameServer/GameServerStatusIndicator/GameServerStatusIndicator.tsx
+++ b/src/components/display/GameServer/GameServerStatusIndicator/GameServerStatusIndicator.tsx
@@ -66,7 +66,7 @@ const GameServerStatusIndicator = (props: {
   }
 
   return (
-    <div className={"flex gap-2 align-middle items-center"}>
+    <div className={"flex gap-2 align-middle items-center"} data-testid="server-status-indicator">
       <GameServerStatusDot status={status} />
       <TooltipWrapper
         tooltip={status === GameServerDtoStatus.PULLING_IMAGE ? tooltipContent : null}

--- a/src/components/display/LogDisplay/LogDisplay.tsx
+++ b/src/components/display/LogDisplay/LogDisplay.tsx
@@ -129,7 +129,7 @@ const LogDisplay = (
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 relative">
+      <div className="flex-1 min-h-0 relative" data-testid="console-log-list">
         <Virtuoso
           ref={logDisplayRef}
           key={displayLogs.length === 0 ? "empty" : "loaded"}
@@ -182,6 +182,7 @@ const LogDisplay = (
         <div className="border-t border-gray-800 p-2 flex gap-2">
           <Input
             type="text"
+            data-testid="console-command-input"
             placeholder={
               isServerRunning ? t("logDisplay.enterCommand") : t("logDisplay.cantSendCommands")
             }
@@ -202,6 +203,7 @@ const LogDisplay = (
           />
           <Button
             onClick={handleSendCommand}
+            data-testid="console-send-btn"
             disabled={!commandInput.trim() || isPending || !isServerRunning}
             size="sm"
             className={"w-fit h-10"}

--- a/src/components/display/Login/LoginBanner/LoginBanner.tsx
+++ b/src/components/display/Login/LoginBanner/LoginBanner.tsx
@@ -21,7 +21,7 @@ const LoginBanner = (props: { setOpen: (open: boolean) => void }) => {
     >
       <div className="flex items-center justify-center gap-9 pt-4">
         <p className="text-xl">{t("signIn.question")}</p>
-        <Button className="h-15" onClick={() => props.setOpen(true)}>
+        <Button className="h-15" data-testid="login-open-btn" onClick={() => props.setOpen(true)}>
           {t("signIn.signIn")}
         </Button>
       </div>

--- a/src/components/display/Login/LoginDialog/LoginForm.tsx
+++ b/src/components/display/Login/LoginDialog/LoginForm.tsx
@@ -36,7 +36,14 @@ const LoginForm = (props: {
       }}
     >
       <FieldGroup className="gap-2">
-        <Input type="text" id="username" name="username" header={t("signIn.username")} required />
+        <Input
+          type="text"
+          id="username"
+          name="username"
+          header={t("signIn.username")}
+          data-testid="login-username-input"
+          required
+        />
 
         <Input
           type={showPassword ? "text" : "password"}
@@ -44,6 +51,7 @@ const LoginForm = (props: {
           name="password"
           header={t("signIn.password")}
           error={props.error}
+          data-testid="login-password-input"
           required
           endDecorator={
             <button

--- a/src/components/display/Login/LoginDisplay/LoginDisplay.tsx
+++ b/src/components/display/Login/LoginDisplay/LoginDisplay.tsx
@@ -51,7 +51,13 @@ const LoginDisplay = () => {
             <DialogDescription>{t("signIn.desc")}</DialogDescription>
             <LoginForm loginCallback={handleLogin} error={error} />
             <DialogFooter>
-              <Button type="submit" form="login-form" disabled={isLoggingIn} className="w-full">
+              <Button
+                type="submit"
+                form="login-form"
+                data-testid="login-submit-btn"
+                disabled={isLoggingIn}
+                className="w-full"
+              >
                 {isLoggingIn ? t("signIn.loading") : t("signIn.signIn")}
               </Button>
               <p className="flex items-center gap-1">

--- a/src/components/display/MemoryLimit/MemoryLimitInput.tsx
+++ b/src/components/display/MemoryLimit/MemoryLimitInput.tsx
@@ -20,6 +20,7 @@ interface MemoryLimitInputProps {
   className?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   error?: string;
+  "data-testid"?: string;
 }
 
 export const MemoryLimitInput = ({
@@ -33,6 +34,7 @@ export const MemoryLimitInput = ({
   className,
   onKeyDown,
   error,
+  "data-testid": dataTestId,
 }: MemoryLimitInputProps) => {
   const [unit, setUnit] = useState<"MiB" | "GiB">("MiB");
   const [localInputValue, setLocalInputValue] = useState("");
@@ -125,6 +127,7 @@ export const MemoryLimitInput = ({
       type="number"
       endDecorator={unitSelector}
       onKeyDown={onKeyDown}
+      data-testid={dataTestId}
     />
   );
 };


### PR DESCRIPTION
## What

Adds 35 `data-testid` attributes across 26 files for the new [Cosy-Systemtest](https://github.com/Magenta-Mause/Cosy-Systemtest) end-to-end suite, which installs Cosy from scratch via `install_cosy.sh` on every release/nightly and drives the features through the real UI.

The ids and their locations come from the audit in `Cosy-Systemtest/docs/testid-gaps.md` (the frontend previously had zero test ids, forcing the suite onto fragile role/label/text selectors). Covered areas: login/logout, home/server list, create-server wizard, server detail/lifecycle, console, file browser.

**Purely additive:** only `data-testid` attributes, plus one optional-prop pass-through in `MemoryLimitInput` (closed prop interface). No behavior, styling, or markup-structure changes — the diff's "deletions" are single-line JSX reformatted to multiline.

Conventions: kebab-case; repeated elements (`server-house`, `file-row`) carry a static id on the container and tests filter by content; dynamic form fields mirror their existing element ids (`create-field-server_name`, …).

## Validation

- `bun run typecheck` clean
- `bun run lint` (biome + tsc) clean, 263 files
- `bun run build` succeeds
- All id literals confirmed present in the production bundle (relevant for shadcn/Radix prop forwarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)