### PR TITLE
Button loading state shows a label instead of a spinner

### DIFF
--- a/docs/conventions/REACT.md
+++ b/docs/conventions/REACT.md
@@ -104,9 +104,20 @@ lazily-fetched panel shows a visible loading state.
 - Pass `loading={isPending}` to the shared `<Button>` (`ui/button.tsx`) for any
   async-triggering button. It disables the button and swaps its label for a translated
   loading label (`loadingLabel` prop to customize, defaults to `common.loading`), and
-  sets `data-loading="true"` (which also drives the loading cursor from `src/index.css`).
-  Derive the flag from the mutation's `isPending` where one exists — don't hand-roll
-  `useState` booleans next to a mutation.
+  sets `data-loading="true"` (which also drives the loading cursor from `src/index.css`)
+  plus `aria-busy`. Derive the flag from the mutation's `isPending` where one exists —
+  don't hand-roll `useState` booleans next to a mutation.
+- Give `loading` only the button's **own** async operation. An unrelated fetch that
+  merely has to gate the control (e.g. a directory listing next to a download button)
+  belongs in `disabled` — otherwise the button gets relabelled for something it isn't
+  doing.
+- Prefer a contextual `loadingLabel` (`common.saving`, `serverStatus.STOPPING`, a
+  download-progress string) over the generic `common.loading` fallback. It is a
+  ReactNode, so pass `<><Icon … />{label}</>` to keep the icon from disappearing
+  mid-flight.
+- Two deliberate exceptions where the label is *not* swapped: `asChild` (Slot requires
+  `Children.only`) and the icon-only sizes (`icon`, `icon-sm`, `icon-lg`, which have no
+  room for text). Both still disable and set `data-loading`.
 - For per-row actions, gate on the acted-on id (via the mutation's `variables`) so only
   the clicked control shows pending, not every row.
 - Give every fetched list or panel a visible **loading** branch and an **error** branch —

--- a/docs/conventions/REACT.md
+++ b/docs/conventions/REACT.md
@@ -102,10 +102,11 @@ lazily-fetched panel shows a visible loading state.
 
 **DO:**
 - Pass `loading={isPending}` to the shared `<Button>` (`ui/button.tsx`) for any
-  async-triggering button. It disables the button, renders an inline pixel-art spinner
-  sized to the button variant, and sets `data-loading="true"` (which also drives the
-  loading cursor from `src/index.css`). Derive the flag from the mutation's `isPending`
-  where one exists — don't hand-roll `useState` booleans next to a mutation.
+  async-triggering button. It disables the button and swaps its label for a translated
+  loading label (`loadingLabel` prop to customize, defaults to `common.loading`), and
+  sets `data-loading="true"` (which also drives the loading cursor from `src/index.css`).
+  Derive the flag from the mutation's `isPending` where one exists — don't hand-roll
+  `useState` booleans next to a mutation.
 - For per-row actions, gate on the acted-on id (via the mutation's `variables`) so only
   the clicked control shows pending, not every row.
 - Give every fetched list or panel a visible **loading** branch and an **error** branch —

--- a/src/components/display/Footer/EditFooterModal.tsx
+++ b/src/components/display/Footer/EditFooterModal.tsx
@@ -22,6 +22,7 @@ interface EditFooterModalProps {
 
 const EditFooterModal = ({ open, onOpenChange, footerData }: EditFooterModalProps) => {
   const { t } = useTranslationPrefix("footer.editModal");
+  const { t: tCommon } = useTranslationPrefix("common");
   const { updateFooter } = useDataInteractions();
   const [formData, setFormData] = useState<FooterUpdateDto>({
     full_name: "",
@@ -128,7 +129,13 @@ const EditFooterModal = ({ open, onOpenChange, footerData }: EditFooterModalProp
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isPending}>
             {t("cancel")}
           </Button>
-          <Button type="submit" form="edit-footer-form" disabled={!isFormValid} loading={isPending}>
+          <Button
+            type="submit"
+            form="edit-footer-form"
+            disabled={!isFormValid}
+            loading={isPending}
+            loadingLabel={tCommon("saving")}
+          >
             {t("save")}
           </Button>
         </DialogFooter>

--- a/src/components/display/GameServer/FileBrowser/FileBrowserDialog/ChangePermissionsModal/ChangePermissionsModal.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserDialog/ChangePermissionsModal/ChangePermissionsModal.tsx
@@ -156,8 +156,13 @@ export const ChangePermissionsModal = ({ open, obj, onClose, onSave }: Props) =>
             <Button variant="secondary" onClick={onClose} disabled={saving} className="flex-1">
               {t("cancel")}
             </Button>
-            <Button onClick={handleSave} loading={saving} className="flex-1">
-              {saving ? t("saving") : t("save")}
+            <Button
+              onClick={handleSave}
+              loading={saving}
+              loadingLabel={t("saving")}
+              className="flex-1"
+            >
+              {t("save")}
             </Button>
           </div>
         </div>

--- a/src/components/display/GameServer/FileBrowser/FileBrowserDialog/EditFileModal/EditFileModal.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserDialog/EditFileModal/EditFileModal.tsx
@@ -107,10 +107,11 @@ export const EditFileModal = ({
             onClick={handleSave}
             disabled={busy || fetching}
             loading={saving}
+            loadingLabel={t("saving")}
             data-testid="editfile-save-btn"
             className="flex-1"
           >
-            {saving ? t("saving") : t("save")}
+            {t("save")}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/display/GameServer/FileBrowser/FileBrowserDialog/FileBrowserActionBar.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserDialog/FileBrowserActionBar.tsx
@@ -59,17 +59,20 @@ export const FileBrowserActionBar = ({
       <Button
         onClick={onDownloadAll}
         loading={downloading.includes(currentPath) || loading}
+        loadingLabel={
+          downloading.includes(currentPath)
+            ? downloadProgress
+              ? t("downloadingFile", {
+                  done: formatBytes(downloadProgress.done),
+                  total: formatBytes(downloadProgress.total),
+                })
+              : t("preparing")
+            : undefined
+        }
         disabled={!canReadFiles || isSynthetic}
       >
         <Icon src={downloadIcon} className="size-5" />
-        {downloading.includes(currentPath)
-          ? downloadProgress
-            ? t("downloadingFile", {
-                done: formatBytes(downloadProgress.done),
-                total: formatBytes(downloadProgress.total),
-              })
-            : t("preparing")
-          : t("downloadAllAction")}
+        {t("downloadAllAction")}
       </Button>
 
       <TooltipWrapper

--- a/src/components/display/GameServer/FileBrowser/FileBrowserDialog/FileBrowserActionBar.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserDialog/FileBrowserActionBar.tsx
@@ -37,6 +37,15 @@ export const FileBrowserActionBar = ({
 }: FileBrowserActionBarProps) => {
   const { t } = useTranslationPrefix("components.fileBrowser.fileBrowserDialog");
 
+  const downloadIconNode = <Icon src={downloadIcon} className="size-5" />;
+  const isDownloading = downloading.includes(currentPath);
+  const downloadingLabel = downloadProgress
+    ? t("downloadingFile", {
+        done: formatBytes(downloadProgress.done),
+        total: formatBytes(downloadProgress.total),
+      })
+    : t("preparing");
+
   return (
     <div className="flex gap-4">
       <TooltipWrapper
@@ -58,20 +67,18 @@ export const FileBrowserActionBar = ({
 
       <Button
         onClick={onDownloadAll}
-        loading={downloading.includes(currentPath) || loading}
+        loading={isDownloading}
         loadingLabel={
-          downloading.includes(currentPath)
-            ? downloadProgress
-              ? t("downloadingFile", {
-                  done: formatBytes(downloadProgress.done),
-                  total: formatBytes(downloadProgress.total),
-                })
-              : t("preparing")
-            : undefined
+          <>
+            {downloadIconNode}
+            {downloadingLabel}
+          </>
         }
-        disabled={!canReadFiles || isSynthetic}
+        // A directory listing fetch (`loading`) is not this button's own async
+        // operation, so it only gates the button — it must not relabel it.
+        disabled={!canReadFiles || isSynthetic || loading}
       >
-        <Icon src={downloadIcon} className="size-5" />
+        {downloadIconNode}
         {t("downloadAllAction")}
       </Button>
 

--- a/src/components/display/GameServer/FileBrowser/FileBrowserDialog/UploadArchiveModal/UploadArchiveModal.tsx
+++ b/src/components/display/GameServer/FileBrowser/FileBrowserDialog/UploadArchiveModal/UploadArchiveModal.tsx
@@ -157,9 +157,10 @@ export const UploadArchiveModal = ({ open, files, onClose, onExtract }: Props) =
                 onClick={handleExtract}
                 disabled={!files?.length}
                 loading={extracting}
+                loadingLabel={t("extracting")}
                 className="flex-1"
               >
-                {extracting ? t("extracting") : t("extract")}
+                {t("extract")}
               </Button>
             </div>
           </div>

--- a/src/components/display/GameServer/GameServerSettings/SettingsActionButtons.tsx
+++ b/src/components/display/GameServer/GameServerSettings/SettingsActionButtons.tsx
@@ -71,9 +71,10 @@ const SettingsActionButtons = ({
             className="h-12.5"
             disabled={confirmDisabled}
             loading={loading}
+            loadingLabel={t("saving")}
             onClick={requireConfirmationLabel ? () => setConfirmationModalOpen(true) : onConfirm}
           >
-            {loading ? t("saving") : t("confirm")}
+            {t("confirm")}
           </Button>
         </TooltipWrapper>
       </div>

--- a/src/components/display/GameServer/GameServerSettings/sections/WebhooksSettingsSection/components/WebhookModal.tsx
+++ b/src/components/display/GameServer/GameServerSettings/sections/WebhooksSettingsSection/components/WebhookModal.tsx
@@ -36,6 +36,7 @@ const DEFAULT_CREATE_VALUES: WebhookFormValues = {
 
 const WebhookModal = ({ mode, gameServerUuid, webhook, open, onOpenChange }: WebhookModalProps) => {
   const { t } = useTranslationPrefix("components.GameServerSettings.webhooks");
+  const { t: tCommon } = useTranslationPrefix("common");
   const { createWebhook, updateWebhook, isCreatingWebhook } = useDataInteractions();
 
   const isEdit = mode === "edit";
@@ -130,7 +131,12 @@ const WebhookModal = ({ mode, gameServerUuid, webhook, open, onOpenChange }: Web
           <Button variant="secondary" onClick={() => handleClose(false)} disabled={isLoading}>
             {t("cancel")}
           </Button>
-          <Button onClick={onFormSubmit} disabled={isDisabled} loading={isLoading}>
+          <Button
+            onClick={onFormSubmit}
+            disabled={isDisabled}
+            loading={isLoading}
+            loadingLabel={tCommon("saving")}
+          >
             {submitLabel}
           </Button>
         </DialogFooter>

--- a/src/components/display/GameServer/GameServerStartStopButton/GameServerStartStopButton.tsx
+++ b/src/components/display/GameServer/GameServerStartStopButton/GameServerStartStopButton.tsx
@@ -39,12 +39,18 @@ const GameServerStartStopButton = (props: {
 
   const icon = <Icon src={powerIcon} variant={props.buttonVariant} className="size-5" />;
 
-  const buttonProps: React.ComponentProps<"button"> = (() => {
+  const buttonProps: React.ComponentProps<typeof Button> = (() => {
     switch (props.gameServer.status) {
       case GameServerDtoStatus.RUNNING:
         return {
           onClick: () => runInteraction(() => stopServer(props.gameServer.uuid)),
           disabled: !canStartStopServer,
+          loadingLabel: (
+            <>
+              {icon}
+              {t("serverStatus.STOPPING")}
+            </>
+          ),
           children: (
             <>
               {icon}
@@ -57,6 +63,12 @@ const GameServerStartStopButton = (props: {
         return {
           onClick: () => runInteraction(() => startServer(props.gameServer.uuid)),
           disabled: !canStartStopServer,
+          loadingLabel: (
+            <>
+              {icon}
+              {t("serverStatus.STARTING")}
+            </>
+          ),
           children: (
             <>
               {icon}

--- a/src/components/display/Login/LoginDisplay/LoginDisplay.tsx
+++ b/src/components/display/Login/LoginDisplay/LoginDisplay.tsx
@@ -56,9 +56,10 @@ const LoginDisplay = () => {
                 form="login-form"
                 data-testid="login-submit-btn"
                 loading={isLoggingIn}
+                loadingLabel={t("loading")}
                 className="w-full"
               >
-                {isLoggingIn ? t("loading") : t("signIn")}
+                {t("signIn")}
               </Button>
               <p className="flex items-center gap-1">
                 Made with{" "}

--- a/src/components/display/UserManagement/ChangePasswordModal/ChangePasswordModal.tsx
+++ b/src/components/display/UserManagement/ChangePasswordModal/ChangePasswordModal.tsx
@@ -22,6 +22,7 @@ interface ChangePasswordModalProps {
 
 export function ChangePasswordModal({ open, onOpenChange, uuid }: ChangePasswordModalProps) {
   const { t } = useTranslationPrefix("changePasswordModal");
+  const { t: tCommon } = useTranslationPrefix("common");
   const [oldPassword, setOldPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -146,6 +147,7 @@ export function ChangePasswordModal({ open, onOpenChange, uuid }: ChangePassword
             form="change-password-form"
             disabled={!isFormValid || hasPasswordError}
             loading={isPending}
+            loadingLabel={tCommon("saving")}
           >
             {t("changePassword")}
           </Button>

--- a/src/components/display/UserManagement/UserDetailPage/modals/ChangePermissionsModal.tsx
+++ b/src/components/display/UserManagement/UserDetailPage/modals/ChangePermissionsModal.tsx
@@ -29,6 +29,7 @@ const ChangePermissionsModal = (props: {
   showCanCreateGameServers: boolean;
 }) => {
   const { t } = useTranslationPrefix("components.userManagement.admin.changePermissionsDialog");
+  const { t: tCommon } = useTranslationPrefix("common");
   const { updateDockerLimits, setCanCreateGameServers } = useDataInteractions();
 
   const [cpu, setCpu] = useState(
@@ -164,7 +165,7 @@ const ChangePermissionsModal = (props: {
           <Button variant="secondary" onClick={handleClose}>
             {t("cancelButton")}
           </Button>
-          <Button onClick={handleSubmit} loading={isPending}>
+          <Button onClick={handleSubmit} loading={isPending} loadingLabel={tCommon("saving")}>
             {t("confirmButton")}
           </Button>
         </DialogFooter>

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import i18n from "i18next";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import enUS from "@/i18n/en-US/translation";
+import { Button } from "./button";
+
+// Standalone i18n instance: the app's `src/i18n/i18n.ts` wires up the browser
+// language detector, which would make the rendered labels depend on the
+// environment. Here the language is pinned so the assertions are exact.
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: "en",
+    resources: { en: { translation: enUS } },
+    interpolation: { escapeValue: false },
+  });
+});
+
+afterEach(cleanup);
+
+// jest-dom is not part of the toolchain, so assertions go through plain DOM state.
+const renderButton = (ui: React.ReactElement) =>
+  render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+
+describe("Button", () => {
+  it("renders its children when idle", () => {
+    renderButton(<Button>Save</Button>);
+
+    const button = screen.getByRole("button") as HTMLButtonElement;
+    expect(button.textContent).toBe("Save");
+    expect(button.disabled).toBe(false);
+    expect(button.getAttribute("aria-busy")).toBeNull();
+    expect(button.getAttribute("data-loading")).toBeNull();
+  });
+
+  it("swaps the children for loadingLabel while loading", () => {
+    renderButton(
+      <Button loading loadingLabel="Saving...">
+        Save
+      </Button>,
+    );
+
+    expect(screen.getByRole("button").textContent).toBe("Saving...");
+  });
+
+  it("falls back to common.loading when no loadingLabel is given", () => {
+    renderButton(<Button loading>Save</Button>);
+
+    expect(screen.getByRole("button").textContent).toBe(enUS.common.loading);
+  });
+
+  it("disables the button and marks it busy while loading", () => {
+    renderButton(<Button loading>Save</Button>);
+
+    const button = screen.getByRole("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute("aria-busy")).toBe("true");
+    expect(button.getAttribute("data-loading")).toBe("true");
+  });
+
+  it("leaves the child untouched under asChild, since Slot needs Children.only", () => {
+    renderButton(
+      <Button asChild loading loadingLabel="Saving...">
+        <a href="/somewhere">Go</a>
+      </Button>,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link.textContent).toBe("Go");
+    expect(link.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("keeps the icon on icon-only sizes instead of rendering a text label", () => {
+    renderButton(
+      <Button size="icon" loading>
+        <svg aria-hidden="true" />
+      </Button>,
+    );
+
+    const button = screen.getByRole("button") as HTMLButtonElement;
+    expect(button.textContent).toBe("");
+    expect(button.querySelector("svg")).not.toBeNull();
+    expect(button.disabled).toBe(true);
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -131,22 +131,38 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
     loading?: boolean;
+    /**
+     * Replaces the children while `loading`; defaults to `common.loading`.
+     * It is a ReactNode, so a call site that wants to keep its icon can pass
+     * `<><Icon … />{t("saving")}</>`.
+     *
+     * Ignored when `asChild` is set, or when `size` is an icon-only variant —
+     * see the render branch below.
+     */
     loadingLabel?: React.ReactNode;
   }) {
   const { t } = useTranslationPrefix("common");
   const Comp = asChild ? Slot : "button";
 
+  // Icon-only buttons are square and have no room for a text label, so they keep
+  // their icon and signal pending through `disabled` + `data-loading` alone.
+  const isIconOnly = size === "icon" || size === "icon-sm" || size === "icon-lg";
+
+  // `asChild` forwards to an arbitrary single child (Slot uses Children.only), so we
+  // must not inject or swap the child — `loadingLabel` is deliberately ignored there,
+  // and only `disabled` + `data-loading` are applied.
+  const showLoadingLabel = loading && !asChild && !isIconOnly;
+
   return (
     <Comp
       data-slot="button"
       data-loading={loading ? "true" : undefined}
+      aria-busy={loading || undefined}
       className={cn(buttonVariants({ variant, size, className }))}
       disabled={disabled || loading}
       {...props}
     >
-      {/* asChild forwards to an arbitrary single child (Slot uses Children.only),
-          so we must not inject or swap the child — just apply disabled + data-loading. */}
-      {asChild ? children : loading ? (loadingLabel ?? t("loading")) : children}
+      {showLoadingLabel ? (loadingLabel ?? t("loading")) : children}
     </Comp>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,8 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
-import reloadIcon from "@/assets/icons/reload.webp";
-import Icon from "@/components/ui/Icon";
+import useTranslationPrefix from "@/hooks/useTranslationPrefix/useTranslationPrefix";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
@@ -118,26 +117,13 @@ const buttonVariants = cva(
   },
 );
 
-// Pending-indicator size per button size variant, matching the icon sizing
-// each variant already uses so the spinner reads as part of the button.
-const spinnerSizeForSize: Record<
-  NonNullable<VariantProps<typeof buttonVariants>["size"]>,
-  string
-> = {
-  default: "size-4",
-  sm: "size-3.5",
-  lg: "size-5",
-  icon: "size-4",
-  "icon-sm": "size-3.5",
-  "icon-lg": "size-5",
-};
-
 function Button({
   className,
   variant,
   size,
   asChild = false,
   loading = false,
+  loadingLabel,
   disabled,
   children,
   ...props
@@ -145,7 +131,9 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
     loading?: boolean;
+    loadingLabel?: React.ReactNode;
   }) {
+  const { t } = useTranslationPrefix("common");
   const Comp = asChild ? Slot : "button";
 
   return (
@@ -157,23 +145,8 @@ function Button({
       {...props}
     >
       {/* asChild forwards to an arbitrary single child (Slot uses Children.only),
-          so we must not inject a sibling — just apply disabled + data-loading. */}
-      {asChild ? (
-        children
-      ) : (
-        <>
-          {loading ? (
-            <Icon
-              src={reloadIcon}
-              className={cn(
-                "animate-spin text-current",
-                spinnerSizeForSize[size ?? "default"],
-              )}
-            />
-          ) : null}
-          {children}
-        </>
-      )}
+          so we must not inject or swap the child — just apply disabled + data-loading. */}
+      {asChild ? children : loading ? (loadingLabel ?? t("loading")) : children}
     </Comp>
   );
 }

--- a/src/i18n/de-DE/translation.ts
+++ b/src/i18n/de-DE/translation.ts
@@ -4,6 +4,7 @@ const translation: i18nLanguage = {
   common: {
     yourLimit: "Dein Limit",
     loading: "Lädt...",
+    saving: "Speichert...",
     required: "Pflichtfeld",
     optional: "Optional",
     removeEntry: "Eintrag entfernen",

--- a/src/i18n/en-US/translation.ts
+++ b/src/i18n/en-US/translation.ts
@@ -4,6 +4,7 @@ const translation: i18nLanguage = {
   common: {
     yourLimit: "Your limit",
     loading: "Loading...",
+    saving: "Saving...",
     required: "Required",
     optional: "Optional",
     removeEntry: "Remove entry",

--- a/src/i18n/i18nKeys.ts
+++ b/src/i18n/i18nKeys.ts
@@ -2,6 +2,7 @@ export type i18nLanguage = {
   common: {
     yourLimit: string;
     loading: string;
+    saving: string;
     required: string;
     optional: string;
     removeEntry: string;


### PR DESCRIPTION
## Why

Design preference follow-up to #115: the inline spinning icon on pending buttons doesn't fit the look. A pending button should simply be disabled and say that it's loading.

## What

- `ui/button.tsx`: the `loading` prop no longer renders a spinner. The button disables, keeps `data-loading` (loading cursor), and swaps its children for a loading label — a new optional `loadingLabel` prop, defaulting to the translated `common.loading` ("Loading..." / "Lädt...").
- Six call sites that previously conditioned their own children on the pending flag were restructured (children = idle label, `loadingLabel` = pending text) so contextual feedback like the file download progress and "saving"/"extracting" labels is preserved.
- Panel spinners (`ui/Spinner.tsx` in LogDisplay/MetricDisplay/MetricGraph) are unchanged — this only affects buttons.
- `docs/conventions/REACT.md` updated to match.

## Verified

`bun run typecheck`, `bun run lint`, and `bun run test` (84/84) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)