### PR TITLE
chore: fix dependabot ecosystem (npm -> bun) and split majors from grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  # "bun", not "npm": this repo's lockfile is bun.lock, which dependabot only
+  # maintains under the bun ecosystem. Under "npm" it rewrote package.json and
+  # left bun.lock untouched, so every PR failed CI on --frozen-lockfile.
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      npm-dependencies:
+      # Majors are excluded from the group on purpose, so they arrive as
+      # individual PRs that can be migrated one at a time. Grouping them here
+      # meant one breaking bump blocked every safe bump riding along with it.
+      bun-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -19,6 +28,9 @@ updates:
       docker-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -29,3 +41,6 @@ updates:
       github-actions-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Dependabot PR batches in this repo were arriving broken. Two separate causes, both fixed here.

**1. Wrong ecosystem for the lockfile.** This repo locks with `bun.lock`, but the config declared `package-ecosystem: "npm"`. Dependabot does not maintain `bun.lock` under the npm ecosystem, so it rewrote `package.json` alone and left the lockfile stale — every PR then failed CI on `bun install --frozen-lockfile` (`error: lockfile had changes, but lockfile is frozen`). Switched to `package-ecosystem: "bun"`, which does maintain `bun.lock`.

**2. Majors grouped with patches.** `patterns: ["*"]` with no `update-types` filter put every update in one PR, so a single breaking major held hostage the safe patch bumps riding along with it. Majors are now excluded from the group and arrive as individual PRs that can be migrated one at a time.

**Tradeoff worth knowing:** the `bun` ecosystem supports version updates but *not* automated security updates. Dependabot alerts will still flag vulnerabilities; it just will not open fix PRs for them automatically.
