### PR TITLE
fix: define global for the production build (app renders blank on load)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,10 +18,18 @@ export default defineConfig({
     }
   ), tailwindcss(),
   ],
+  // sockjs-client (via react-stomp-hooks) references the Node `global` identifier, which does
+  // not exist in browsers. This must be a top-level `define` so it applies to the production
+  // build: the `optimizeDeps.esbuildOptions.define` below only covers dev pre-bundling, which
+  // is why the built app threw "global is not defined" while dev worked fine.
+  define: {
+    global: "globalThis",
+  },
   resolve: {
     alias: {
-      // Polyfill for global
-      global: "global",
+      // NOTE: there used to be a `global: "global"` alias here. It aliased to an npm package
+      // that is not a dependency of this project, so it never resolved anything; the `define`
+      // above is what actually provides `global`.
       "@": path.resolve(__dirname, "./src"),
     },
   },


### PR DESCRIPTION
## The outage

The deployed app at cosy.jannekeipert.de crashes on load and renders **nothing**:

```
Uncaught ReferenceError: global is not defined
    AuthProvider-CQDz9-05.js:9
```

Reproduced against the live site with headless Chromium: 1 page error, body does not render.

## Cause

`sockjs-client` (pulled in by `react-stomp-hooks`) references the Node `global` identifier, which does not exist in browsers. The config *did* try to handle this — but neither mechanism covered the production build:

| Existing config | Why it didn't help |
|---|---|
| `optimizeDeps.esbuildOptions.define.global` | Applies only to **dev pre-bundling**. This is why `bun dev` worked and only the built app broke. |
| `resolve.alias.global = "global"` | Aliased to an npm package that **is not a dependency of this project** (`node_modules/global` does not exist), so it never resolved anything. Also, an alias maps module *specifiers* — it can't rewrite a bare identifier reference anyway. |

**Why now:** the Vite 7 → 8 bump in #127 switched the bundler to **Rolldown**, which preserves sockjs-client's `global` references where Rollup eliminated them. Verified by building `8a357ed^` (the commit immediately before that bump): **zero** chunks contain a bare `global`, versus many on current `main`. So this is a latent config bug that the bundler change exposed — #127 isn't itself wrong.

## Fix

Move the substitution to a **top-level `define`**, which applies to the production build too, and delete the dead alias. One-line behavioural change.

## Verification

Headless Chromium, 3 runs per build:

| Build | `global is not defined` | Renders |
|---|---|---|
| Live site (current `main`) | **yes** | **no — blank** |
| This branch | none | yes |
| `8a357ed^` (pre-bump Vite 7, known-good) — control | none | yes |

This branch and the known-good control render identically ("COSY By Medalheads…", body ~16KB) with **zero page errors** across all runs. I served both from the same static server with no backend, so the comparison is apples-to-apples.

I also checked `Buffer`, since the dev-only polyfill sets `buffer: true`: every occurrence in the built output is benign — `arrayBuffer()`, a `sendBuffer` property name, and guarded `isBuffer` checks. **No Buffer polyfill is needed for production**, so I did not add one.

`bun run lint`, `bun run typecheck` and all **90 tests** pass.

## Worth a follow-up

CI builds the app but never loads it, so nothing could catch a crash-on-boot: `lint`, `typecheck` and `test` all pass on the broken `main`. A smoke test that serves `dist` and asserts the page renders with no `pageerror` would catch this whole class of failure — Playwright is already in use over in `Cosy-Systemtest`. Happy to add it if you want.

Also noted while testing, **pre-existing and unrelated** (present on the pre-bump control too): `Failed to decode token: InvalidTokenError: Invalid token specified: invalid base64 for part #2` fires on a fresh load with no session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)